### PR TITLE
Updating deprecated code in accordance with EIP-1102

### DIFF
--- a/src/VueMetamask.vue
+++ b/src/VueMetamask.vue
@@ -109,7 +109,7 @@ export default {
       if (window.ethereum) {
         window.web3 = new Web3(ethereum);
         try {
-          await ethereum.enable();
+          await ethereum.send("eth_requestAccounts");
           this.web3TimerCheck(window.web3);
         } catch (error) {
           this.Log(


### PR DESCRIPTION
Fix #15 

## Changes :

According to the EIP-1102, the `enable` method is deprecated and need to be replaced by a new RPC method called `eth_requestAccounts`, thus requiring an update of this component source code.

For further informations : https://eips.ethereum.org/EIPS/eip-1102